### PR TITLE
Fix errors with unknown tags in `parse()` (#4) and `strip()` (#6)

### DIFF
--- a/ansimarkup/__init__.py
+++ b/ansimarkup/__init__.py
@@ -1,4 +1,4 @@
-from . markup import AnsiMarkup, AnsiMarkupError, MismatchedTag
+from . markup import AnsiMarkup, AnsiMarkupError, MismatchedTag, UnbalancedTag
 
 
 _ansimarkup = AnsiMarkup()
@@ -6,4 +6,4 @@ parse = _ansimarkup.parse
 ansiprint = _ansimarkup.ansiprint
 
 
-__all__ = 'AnsiMarkup', 'AnsiMarkupError', 'MismatchedTag', 'parse', 'ansiprint'
+__all__ = 'AnsiMarkup', 'AnsiMarkupError', 'MismatchedTag', 'UnbalancedTag', 'parse', 'ansiprint'

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -23,36 +23,134 @@ def test_flat_colors():
 	assert p('<b,r,y>1</b,r,y>') == p('<bold,red,yellow>1</bold,red,yellow>') == S.BRIGHT + F.RED + B.YELLOW + '1' + S.RESET_ALL
 	assert p('<b,r,>1</b,r,>') == p('<bold,red,>1</bold,red,>') == S.BRIGHT + F.RED + '1' + S.RESET_ALL
 
+	assert p('<fg RED>1</fg RED>') == '<fg RED>1</fg RED>'
+	assert p('<fg light-blue2>1</fg light-blue2>') == '<fg light-blue2>1</fg light-blue2>'
+
+	assert p('<bg ,red>1</bg ,red>') == '<bg ,red>1</bg ,red>'
+	assert p('<bg red,>1</bg red,>') == '<bg red,>1</bg red,>'
+	assert p('<bg a,z>1</bg a,z>') == '<bg a,z>1</bg a,z>'
+	assert p('<bg blue,yelllow>1</bg blue,yelllow>') == '<bg blue,yelllow>1</bg blue,yelllow>'
+	assert p('<bg r, y>1</bg r, y>') == '<bg r, y>1</bg r, y>'
+
+	assert p('<>1</>') == '<>1</>'
+	assert p('</>1</>') == '</>1</>'
+	assert p('<,>1</,>') == '<,>1</,>'
+	assert p('<,,>1</,,>') == '<,,>1</,,>'
+	assert p('<z,z>1</z,z>') == '<z,z>1</z,z>'
+	assert p('<z,z,z>1</z,z,z>') == '<z,z,z>1</z,z,z>'
+
+	assert p('<red,RED>1</red,RED>') == '<red,RED>1</red,RED>'
+	assert p('<bold,red>1</bold,red>') == '<bold,red>1</bold,red>'
+	assert p('<b,red,RED>1</b,red,RED>') == '<b,red,RED>1</b,red,RED>'
+	assert p('<b,red,bold>1</b,red,bold>') == '<b,red,bold>1</b,red,bold>'
+	assert p('<b,,>1</b,,>') == '<b,,>1</b,,>'
+	assert p('<b,a,>1</b,a,>') == '<b,a,>1</b,a,>'
+	assert p('<b,,z>1</b,,z>') == '<b,,z>1</b,,z>'
+
 
 def test_xterm_color():
 	assert p('<fg 200>1</fg 200>') == '\x1b[38;5;200m' '1' '\x1b[0m'
 	assert p('<bg 100><fg 200>1')  == '\x1b[48;5;100m' '\x1b[38;5;200m' '1'
+
 	assert p('<fg 256>1')          == '<fg 256>1'
+	assert p('<bg 256>1</bg 256>') == '<bg 256>1</bg 256>'
+	assert p('<bg 12 >1</bg 12 >') == '<bg 12 >1</bg 12 >'
+	assert p('<bg 2222>1</bg 2222>') == '<bg 2222>1</bg 2222>'
 
 
 def test_xterm_hex():
-	assert p('<fg #ff0000>1') == '\x1b[38;2;255;0;0m' '1'
+	assert p('<fg #ff0000>1') == p('<fg #FF0000>1') == '\x1b[38;2;255;0;0m' '1'
 	assert p('<bg #00A000><fg #ff0000>1') == '\x1b[48;2;0;160;0m' '\x1b[38;2;255;0;0m' '1'
+	assert p('<fg #F12>1</fg #F12>') == p('<fg #F12F12>1</fg #F12F12>') == '\x1b[38;2;241;47;18m' + '1' + S.RESET_ALL
+
+	assert p('<fg #>1</fg #>') == '<fg #>1</fg #>'
+	assert p('<bg #12>1</bg #12>') == '<bg #12>1</bg #12>'
+	assert p('<fg #1234567>1</fg #1234567>') == '<fg #1234567>1</fg #1234567>'
+	assert p('<bg #E7G>1</bg #E7G>') == '<bg #E7G>1</bg #E7G>'
+	assert p('<fg #F2D1GZ>1</fg #F2D1GZ>') == '<fg #F2D1GZ>1</fg #F2D1GZ>'
 
 
 def test_xterm_rgb():
 	assert p('<fg 255,0,0>1') == p('<fg #ff0000>1') == '\x1b[38;2;255;0;0m' '1'
 	assert p('<bg 0,160,0><fg 255,0,0>1') == p('<bg #00A000><fg #ff0000>1') == '\x1b[48;2;0;160;0m' '\x1b[38;2;255;0;0m' '1'
 
+	assert p('<fg>1</fg>') == '<fg>1</fg>'
+	assert p('<fg >1</fg >') == '<fg >1</fg >'
+	assert p('<fg ,>1</fg ,>') == '<fg ,>1</fg ,>'
+	assert p('<fg ,,>1</fg ,,>') == '<fg ,,>1</fg ,,>'
+	assert p('<fg ,,,>1</fg ,,,>') == '<fg ,,,>1</fg ,,,>'
+	assert p('<fg 1,2,>1</fg 1,2,>') == '<fg 1,2,>1</fg 1,2,>'
+	assert p('<fg 256,120,120>1</fg 256,120,120>') == '<fg 256,120,120>1</fg 256,120,120>'
+
 
 def test_nested():
 	assert p('0<b>1<d>2</d>3</b>4') == '0' + S.BRIGHT + '1' + S.DIM + '2' + S.RESET_ALL + S.BRIGHT + '3' + S.RESET_ALL + '4'
+	assert p('<d>0<b>1<d>2</d>3</b>4</d>') == S.DIM + '0' + S.BRIGHT + '1' + S.DIM + '2' + S.RESET_ALL + S.DIM + S.BRIGHT + '3' + S.RESET_ALL + S.DIM +'4' + S.RESET_ALL
 
 
-def test_errors():
+def test_mismatched_error():
 	with raises(MismatchedTag):
 		p('<b>1</d>')
+
+	with raises(MismatchedTag):
+		p('</b>')
+
+	with raises(MismatchedTag):
+		p('<b>1</b></b>')
+
+	with raises(MismatchedTag):
+		p('<red><b>1</b></b></red>')
+
+	with raises(MismatchedTag):
+		p('<tag>1</b>')
+
+
+def test_unbalanced_error():
+	with raises(UnbalancedTag):
+		p('<r><Y>1</r>2</Y>')
+
+	with raises(UnbalancedTag):
+		p('<r><r><Y>1</r>2</Y></r>')
+
+	with raises(UnbalancedTag):
+		p('<r><Y><r></r></r></Y>')
+
+
+def test_unknown_tags():
+	assert p('<tag>1</tag>') == '<tag>1</tag>'
+	assert p('<tag>') == '<tag>'
+	assert p('</tag>') == '</tag>'
+
+	assert p('<b>1</b><tag>2</tag>') == S.BRIGHT + '1' + S.RESET_ALL + '<tag>2</tag>'
+	assert p('<tag>1</tag><b>2</b>') == '<tag>1</tag>' + S.BRIGHT + '2' + S.RESET_ALL
+
+	assert p('<b>1</b><tag>2</tag><b>3</b>') == S.BRIGHT + '1' + S.RESET_ALL + '<tag>2</tag>' + S.BRIGHT + '3' + S.RESET_ALL
+	assert p('<tag>1</tag><b>2</b><tag>3</tag>') == '<tag>1</tag>' + S.BRIGHT + '2' + S.RESET_ALL + '<tag>3</tag>'
+
+	assert p('<b><tag>1</tag></b>') == S.BRIGHT + '<tag>1</tag>' + S.RESET_ALL
+	assert p('<tag><b>1</b></tag>') == '<tag>' + S.BRIGHT + '1' + S.RESET_ALL + '</tag>'
+
+	assert p('<b><tag>1</tag>') == S.BRIGHT + '<tag>1</tag>'
+	assert p('<tag>1</tag><b>') == '<tag>1</tag>' + S.BRIGHT
+
+	assert p('<b><tag>') == S.BRIGHT + '<tag>'
+	assert p('<tag><b>') == "<tag>" + S.BRIGHT
+
+	assert p('<b></tag>') == S.BRIGHT + '</tag>'
+	assert p('</tag><b>') == "</tag>" + S.BRIGHT
 
 
 def test_strip(am):
 	assert am.strip('<b>1</b>2<d>3</d>') == '123'
 	assert am.strip('<bold,red,yellow>1</bold,red,yellow>') == '1'
+	assert am.strip('<r><tag>1</tag></r>') == '<tag>1</tag>'
+	assert am.strip('<tag><r>1</r></tag>') == '<tag>1</tag>'
+	assert am.strip('<tag><r>1</tag></r>') == '<tag>1</tag>'
+	assert am.strip('<r><b>1</r></b>') == '1'
+	assert am.strip('<fg red>1<fg red>') == '1'
 
+	am = AnsiMarkup(tags={'red':'<red>', 'b,g,r':'<b,g,r>', 'fg 1,2,3': '</fg 1,2,3>'})
+	assert am.strip('<red>1</red><b,g,r>2</b,g,r><fg 1,2,3>3</fg 1,2,3>') == '123'
 
 def test_options():
 	am = AnsiMarkup(always_reset=True)
@@ -87,7 +185,3 @@ def test_tag_chars():
 	r1 = p('0<b>1<d>2</d>3</b>4')
 	r2 = am.parse('0{b}1{d}2{/d}3{/b}4')
 	assert r1 == r2 == '0' + S.BRIGHT + '1' + S.DIM + '2' + S.RESET_ALL + S.BRIGHT + '3' + S.RESET_ALL + '4'
-
-@mark.xfail
-def test_limitations():
-	assert p('<r><Y>1</r>2</Y>') == F.RED + B.YELLOW + '1' + S.RESET_ALL + B.YELLOW + '2' + S.RESET_ALL


### PR DESCRIPTION
I slightly refactored the way tags are parsed. I use only one regex pass that searches both opening and closing tags. When a closing tag is detected, we just have to compare it to the last element of `tag_list` which corresponds to the last tag opened. If the markup is correct, both tags must match each other. This method also allows to raise an `UnbalancedTag` exception in case they are different. This also avoids having to use `.index()` and `del` as I have seen mentioned in the README. Unknown tags are not added to the list and are therefore not overwritten and error-free.

I also tried another method using a single large regex that matched all the correct tags, but it was ~30% slower in the end. This method should not add overhead according to my measurements.

I have made the parsing more strict to prevent false positives from being detected and replaced (e.g. `<red,unknown>` and `<bg #Z>` tags will not be replaced). In addition, the semi-hexadecimal colors (like `#FFF`) are translated correctly.

I modified the `strip()` function to no longer replace the unknown tags. The method used is a bit hacky but it was to avoid having to copy the function `sub_tag` entirely.

Finally, I also added some unit tests to check the expected behavior on some edge cases that I had spotted.

Tell me what you think of these changes and if you want me to improve anything. 😃 