### PR TITLE
Fix error with tag separators outside of markups (#8)

### DIFF
--- a/ansimarkup/markup.py
+++ b/ansimarkup/markup.py
@@ -161,16 +161,16 @@ class AnsiMarkup:
     def compile_tag_regex(self, tag_sep):
         # Optimize the default:
         if tag_sep == '<>':
-            tag_regex = re.compile(r'</?([^>]+)>')
+            tag_regex = re.compile(r'</?([^<>]+)>')
             return tag_regex
 
-        if len(tag_sep) < 2:
-            raise ValueError('tag_sep needs to have at least two element (e.g. "<>")')
+        if len(tag_sep) != 2:
+            raise ValueError('tag_sep needs to have exactly two elements (e.g. "<>")')
 
         if tag_sep[0] == tag_sep[1]:
             raise ValueError('opening and closing characters cannot be the same')
 
-        tag_regex = r'{0}/?([^{1}]+){1}'.format(tag_sep[0], tag_sep[1])
+        tag_regex = r'{0}/?([^{0}{1}]+){1}'.format(tag_sep[0], tag_sep[1])
         return re.compile(tag_regex)
 
 


### PR DESCRIPTION
An opening tag separator preceding a markup would raise an error.

For example : `parse("< <red>1</red>")`

The regex looking for markups was not excluding opening seprator from the tags.

Some unit tests has been added to check the expected behavior.

Also, the `tag_sep` has been slightly modified to make it stricter and to accept only
argument with exactly two elements.