### PR TITLE
Add "strict" option to raise error on missing closing tag

### DIFF
--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -116,6 +116,19 @@ def test_unbalanced_error():
 		p('<r><Y><r></r></r></Y>')
 
 
+def test_strict_parsing():
+	am = AnsiMarkup(strict=True)
+
+	with raises(MismatchedTag):
+		am.parse('<b>')
+
+	with raises(MismatchedTag):
+		am.parse('<Y><b></b>')
+
+	with raises(MismatchedTag):
+		am.parse('<b><b></b>')
+
+
 def test_unknown_tags():
 	assert p('<tag>1</tag>') == '<tag>1</tag>'
 	assert p('<tag>') == '<tag>'


### PR DESCRIPTION
Hi.

I quickly implemented a small option to throw an error if a tag is opened but never closed during parsing. By default of course the behavior remains the same, but users can use `strict=True` to punish any laxness in the markup!

```python
>>> from ansimarkup import AnsiMarkup
>>> am = AnsiMarkup(strict=True)
>>> am.parse("<red>I'm too lazy to close this tag")
ansimarkup.markup.MismatchedTag: opening tag "<red>" has no corresponding closing tag
```

Basically, I plan to use it for "arbitrary" strings, and I would like to being notified that something is wrong with the markups rather than having colors potentially "leaking" outside of the string's "scope".

Let me know if you want me to add anything to this PR. 👍 