### PR TITLE
Fix bdist_rpm error python3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,12 +33,15 @@ extras_require = {
     ]
 }
 
+with open("README.rst", "rb") as file:
+    readme = file.read().decode("utf-8")
+
 kw = {
     'name':                 'ansimarkup',
     'version':              '1.4.0',
 
     'description':          'Produce colored terminal text with an xml-like markup',
-    'long_description':     open('README.rst').read(),
+    'long_description':     readme,
 
     'author':               'Georgi Valkov',
     'author_email':         'georgi.t.valkov@gmail.com',


### PR DESCRIPTION
I tried to create rpm, but I corrected it because I got an error.
This is my first pull requst.

```
$ python setup.py bdist_rpm
Traceback (most recent call last):
  File "setup.py", line 41, in <module>
    'long_description':     open('README.rst').read(),
  File "/usr/lib64/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xce in position 5975: ordinal not in range(128)

```