### PR TITLE
Fix README example syntax

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ Ansimarkup is an XML-like markup for producing colored terminal text.
 
   from ansimarkup import ansiprint as print
 
-  print("<b>bold text</b>"))
+  print("<b>bold text</b>")
   print("<red>red text</red>", "<red,green>red text on a green background</red,green>")
   print("<fg #ffaf00>orange text</fg #ffaf00>")
 

--- a/README.rst
+++ b/README.rst
@@ -91,13 +91,13 @@ Custom tags or overrides for existing tags may be defined by creating a new
 
   user_tags = {
       # Add a new tag (e.g. we want <info> to expand to "<bold><green>").
-      "info": parse("<b><g>")
+      "info": parse("<b><g>"),
 
       # The ansi escape sequence can be used directly.
       "info": "e\x1b[32m\x1b[1m",
 
       # Tag names may also be callables.
-      "err":  lambda: parse("<r>")
+      "err":  lambda: parse("<r>"),
 
       # Colors may also be given convenient tag names.
       "orange": parse("<fg #d78700>"),


### PR DESCRIPTION
Copy-pasted and noticed a syntax error. Here's a quick fix for that. Thanks! 