### PR TITLE
Fix "HIDE" and "STRIKE" inverted ansi codes

### DIFF
--- a/ansimarkup/ansi.py
+++ b/ansimarkup/ansi.py
@@ -7,8 +7,8 @@ class AnsiExtendedStyle(AnsiCodes):
     UNDERLINE = 4
     BLINK = 5
     REVERSE = 7
-    STRIKE = 8
-    HIDE = 9
+    HIDE = 8
+    STRIKE = 9
 
 
 ExtendedStyle = AnsiExtendedStyle()


### PR DESCRIPTION
Hi. :)

It seems `"HIDE"` should use ansi code `8` and `"STRIKE"` should use ansi code `9`.

[According to Wikipedia](https://en.wikipedia.org/wiki/ANSI_escape_code):

> n | Name | Note
> -- | -- | --
> 8 | Conceal or hide | Not widely supported.
> 9 | Crossed-out, or strike | Characters legible but marked as if for deletion. Not supported in Terminal.app

I actually introduced this bug myself a few years ago in issue https://github.com/gvalkov/python-ansimarkup/pull/11. 😄

Thanks to @tunaflsh for the initial report!