### PR TITLE
Fix wrong conversion of short hex color codes

### DIFF
--- a/ansimarkup/markup.py
+++ b/ansimarkup/markup.py
@@ -143,7 +143,8 @@ class AnsiMarkup:
             elif re.match(r"#(?:[a-fA-F0-9]{3}){1,2}$", color):
                 hex_color = color[1:]
                 if len(hex_color) == 3:
-                    hex_color *= 2
+                    r, g, b = hex_color
+                    hex_color = r * 2 + g * 2 + b * 2
                 res = "\033[%s;2;%s;%s;%sm" % ((code,) + hex_to_rgb(hex_color))
             elif color.count(",") == 2:
                 colors = tuple(color.split(","))

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -67,7 +67,7 @@ def test_xterm_color():
 def test_xterm_hex():
     assert p("<fg #ff0000>1") == p("<fg #FF0000>1") == "\x1b[38;2;255;0;0m" "1"
     assert p("<bg #00A000><fg #ff0000>1") == "\x1b[48;2;0;160;0m" "\x1b[38;2;255;0;0m" "1"
-    assert p("<fg #F12>1</fg #F12>") == p("<fg #F12F12>1</fg #F12F12>") == "\x1b[38;2;241;47;18m" + "1" + S.RESET_ALL
+    assert p("<fg #F12>1</fg #F12>") == p("<fg #FF1122>1</fg #FF1122>") == "\x1b[38;2;255;17;34m" + "1" + S.RESET_ALL
 
     assert p("<fg #>1</fg #>") == "<fg #>1</fg #>"
     assert p("<bg #12>1</bg #12>") == "<bg #12>1</bg #12>"


### PR DESCRIPTION
Hi.

Just there to fix a bug I introduced 8 years ago in #7...

> In addition, the semi-hexadecimal colors (like `#FFF`) are translated correctly.

Yeah, "correctly", sure... :sweat_smile:
`#ABC` should translates to `#AABBCC`, not `#ABCABC`.

Thanks to @turkoid for the initial report.